### PR TITLE
Json Data Formatting

### DIFF
--- a/src/cuckoo_miner/cuda_miner_adds.h
+++ b/src/cuckoo_miner/cuda_miner_adds.h
@@ -81,7 +81,7 @@ void populate_device_info(){
 
 extern "C" int cuckoo_get_stats(char* prop_string, int* length){
     int remaining=*length;
-    const char* device_stat_json = "{\"device_id\":\"%d\",\"device_name\":\"%s\",\"last_start_time\":%lld,\"last_end_time\":%lld,\"last_solution_time\":%d,\"iterations_completed\":%d}";
+    const char* device_stat_json = "{\"device_id\":\"%d\",\"device_name\":\"%s\",\"last_start_time\":%lld,\"last_end_time\":%lld,\"last_solution_time\":%lld,\"iterations_completed\":%d}";
     //minimum return is "[]\0"
     if (remaining<=3){
         //TODO: Meaningful return code


### PR DESCRIPTION
I get the following error with the current formatting:

Test mining for 75 seconds, looking for difficulty > 0
Plugin (Sync Mode): /home/chris/cuckoo-miner/cuckoo-miner/target/debug/plugins/lean_cuda_30.cuckooplugin
Stats_json: [{"device_id":"0","device_name":"GeForce GTX 960","last_start_time":1512081360858757164,"last_end_time":1512081368290639175,"last_solution_time":-1158052581,"iterations_completed":1},{"device_id":"1","device_name":"GeForce GTX 960","last_start_time":0,"last_end_time":0,"last_solution_time":0,"iterations_completed":0}]
thread 'on_cuda_commit_mine_sync' panicked at 'called `Result::unwrap()` on an `Err` value: StatsError("Error retrieving stats from plugin: ErrorImpl { code: Message(\"invalid value: integer `-1158052581`, expected u64\"), line: 1, column: 156 }")', /checkout/src/libcore/result.rs:906:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
test on_cuda_commit_mine_sync ... FAILED

failures:

failures:
    on_cuda_commit_mine_sync